### PR TITLE
fix(README) : il faut mettre yarn dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you are working with several versions of NodeJS, we recommend you install [nv
 ### 2.2 Starting the project
 
 - The `docker image build --no-cache -t micro-api .` command will allow you to build your image.
-- The `docker container run --name micro-api -p 3000:3000 -dt micro-api yarn` command will allow you to create your Docker container and run your image on port 3000.
+- The `docker container run --name micro-api -p 3000:3000 -dt micro-api yarn dev` command will allow you to create your Docker container and run your image on port 3000.
 - The `docker container stop micro-api` command will allow you to stop your micro-api.
 - The `docker container rm micro-api` command will allow you to delete your micro-api container.
 


### PR DESCRIPTION
`yarn` fait l'équivalent de `npm install`  alors que `yarn dev` lance le serveur